### PR TITLE
Fix: MetaMask network switch confirmation

### DIFF
--- a/.changeset/fix-network-switch-confirmation.md
+++ b/.changeset/fix-network-switch-confirmation.md
@@ -1,0 +1,9 @@
+---
+"@gonzalomelov/dappwright": patch
+---
+
+Fix network switch confirmation handling for MetaMask
+
+- Add proper popup load state waiting before interaction
+- Bring popup to front to ensure it's active
+- Support both 'page-container-footer-next' and 'confirmation-submit-button' selectors for broader MetaMask version compatibility

--- a/src/wallets/metamask/actions/confirmNetworkSwitch.ts
+++ b/src/wallets/metamask/actions/confirmNetworkSwitch.ts
@@ -1,10 +1,16 @@
 import { Page } from 'playwright-core';
+
 import { waitForChromeState } from '../../../helpers';
 import { performPopupAction } from './util';
 
 export const confirmNetworkSwitch = (page: Page) => async (): Promise<void> => {
   await performPopupAction(page, async (popup) => {
-    await popup.getByTestId('page-container-footer-next').click();
+    // Wait for popup to load
+    await popup.waitForLoadState();
+    await popup.bringToFront();
+
+    await popup.getByTestId('page-container-footer-next').or(popup.getByTestId('confirmation-submit-button')).click();
+
     await waitForChromeState(page);
   });
 };


### PR DESCRIPTION
## Summary
Fixes network switch confirmation handling for newer MetaMask versions.

## Changes
- Add proper popup load state waiting before interaction
- Bring popup to front to ensure it's active  
- Support both 'page-container-footer-next' and 'confirmation-submit-button' selectors for broader MetaMask version compatibility

## Test plan
- [x] Tested network switching with latest MetaMask version
- [x] Verified backward compatibility with older selectors